### PR TITLE
[BUGFIX] Restore colPos filter for IRRE children

### DIFF
--- a/Classes/Form/FormDataProvider/TcaColPosItems.php
+++ b/Classes/Form/FormDataProvider/TcaColPosItems.php
@@ -24,7 +24,6 @@ class TcaColPosItems implements FormDataProviderInterface
     {
         if ('tt_content' !== $result['tableName']
             || empty($result['processedTca']['columns']['colPos']['config']['items'])
-            || !empty($result['isInlineChild'])
         ) {
             return $result;
         }


### PR DESCRIPTION
This ensures the colPos field is also filtered for IRRE children.