### PR TITLE
[BUGFIX] Exclude disabled (not assigned) columns

### DIFF
--- a/Classes/BackendLayout/BackendLayoutConfiguration.php
+++ b/Classes/BackendLayout/BackendLayoutConfiguration.php
@@ -66,7 +66,7 @@ class BackendLayoutConfiguration
             }
 
             foreach ($row['columns.'] as $column) {
-                if ($colPos === (int)$column['colPos']) {
+                if ($column['colPos'] !== '' && $colPos === (int)$column['colPos']) {
                     $configuration = $column;
                     break 2;
                 }

--- a/Tests/Functional/Fixtures/TSconfig/BackendLayouts/Default.ts
+++ b/Tests/Functional/Fixtures/TSconfig/BackendLayouts/Default.ts
@@ -9,7 +9,13 @@ mod.web_layout.BackendLayouts.default {
                     1 {
                         name = Border (all)
                         colPos = 3
-                        colspan = 3
+                        colspan = 5
+                    }
+
+
+                    2 {
+                        name = Disabled
+                        colPos =
                     }
                 }
             }
@@ -19,7 +25,7 @@ mod.web_layout.BackendLayouts.default {
                     1 {
                         name = Normal (header, textmedia, list[-indexed_search_pi2])
                         colPos = 0
-                        colspan = 3
+                        colspan = 6
                         allowed {
                             CType = header, textmedia, list
                         }


### PR DESCRIPTION
In backend layout configuration columns with empty colPos can be defined.
Those columns need to be excluded from configuration resolving.

Resolves: #37 