### PR TITLE
[WIP] [BUGFIX] Check for "maxitems" on the creation of new content elements only

### DIFF
--- a/Classes/Form/FormDataProvider/TcaColPosItems.php
+++ b/Classes/Form/FormDataProvider/TcaColPosItems.php
@@ -75,11 +75,12 @@ class TcaColPosItems implements FormDataProviderInterface
                 }
             }
 
-            if (!empty($columnConfiguration['maxitems'])
+            if ($result['command'] === 'new'
+                && !empty($columnConfiguration['maxitems'])
                 && $columnConfiguration['maxitems'] <= $this->contentRepository->countColPosByRecord($record)
             ) {
                 if ($colPos === (int)$result['databaseRow']['colPos'][0]) {
-                    throw  new AccessDeniedColPosException(
+                    throw new AccessDeniedColPosException(
                         'Maximum number of allowed content elements (' . $columnConfiguration['maxitems'] . ') reached.',
                         1494605357
                     );


### PR DESCRIPTION
Otherwise it's not allowed to edit any content elements once "maxitems" is reached.
`maxitems = 1` doesn't work without this fix, too.

Fixes #36 or at least tries to ;)