### PR TITLE
Remove deprecated property calls

### DIFF
--- a/Classes/Hooks/WizardItemsHook.php
+++ b/Classes/Hooks/WizardItemsHook.php
@@ -29,10 +29,10 @@ class WizardItemsHook implements NewContentElementWizardHookInterface
      */
     public function manipulateWizardItems(&$wizardItems, &$parentObject)
     {
-        $pageId = (int) GeneralUtility::_GET('id');
+        $pageId = (int)GeneralUtility::_GET('id');
         $backendLayoutConfiguration = BackendLayoutConfiguration::createFromPageId($pageId);
 
-        $colPos = (int) GeneralUtility::_GET('colPos');
+        $colPos = (int)GeneralUtility::_GET('colPos');
         $columnConfiguration = $backendLayoutConfiguration->getConfigurationByColPos($colPos);
         if (empty($columnConfiguration) || (empty($columnConfiguration['allowed.']) && empty($columnConfiguration['disallowed.']))) {
             return;

--- a/Classes/Hooks/WizardItemsHook.php
+++ b/Classes/Hooks/WizardItemsHook.php
@@ -29,10 +29,10 @@ class WizardItemsHook implements NewContentElementWizardHookInterface
      */
     public function manipulateWizardItems(&$wizardItems, &$parentObject)
     {
-        $pageId = (int)GeneralUtility::_GET('id');
+        $pageId = (int)GeneralUtility::_GP('id');
         $backendLayoutConfiguration = BackendLayoutConfiguration::createFromPageId($pageId);
 
-        $colPos = (int)GeneralUtility::_GET('colPos');
+        $colPos = (int)GeneralUtility::_GP('colPos');
         $columnConfiguration = $backendLayoutConfiguration->getConfigurationByColPos($colPos);
         if (empty($columnConfiguration) || (empty($columnConfiguration['allowed.']) && empty($columnConfiguration['disallowed.']))) {
             return;

--- a/Classes/Hooks/WizardItemsHook.php
+++ b/Classes/Hooks/WizardItemsHook.php
@@ -29,10 +29,10 @@ class WizardItemsHook implements NewContentElementWizardHookInterface
      */
     public function manipulateWizardItems(&$wizardItems, &$parentObject)
     {
-        $pageId = $parentObject->id;
+        $pageId = (int) GeneralUtility::_GET('id');
         $backendLayoutConfiguration = BackendLayoutConfiguration::createFromPageId($pageId);
 
-        $colPos = (int)$parentObject->colPos;
+        $colPos = (int) GeneralUtility::_GET('colPos');
         $columnConfiguration = $backendLayoutConfiguration->getConfigurationByColPos($colPos);
         if (empty($columnConfiguration) || (empty($columnConfiguration['allowed.']) && empty($columnConfiguration['disallowed.']))) {
             return;


### PR DESCRIPTION
Remove deprecated property calls.

In TYPO3 v9.2 access to $parentObject->id and $parentObject->colPos is deprecated

> Core: Error handler (BE): TYPO3 Deprecation Notice: Using $id of NewContentElementController from the outside is discouraged as this variable is used for internal storage. in web/typo3/sysext/core/Classes/Compatibility/PublicPropertyDeprecationTrait.php line 101 

> Core: Error handler (BE): TYPO3 Deprecation Notice: Using $colPos of NewContentElementController from the outside is discouraged as this variable is used for internal storage. in web/typo3/sysext/core/Classes/Compatibility/PublicPropertyDeprecationTrait.php line 101 

The value for page id could alternatively retrieved by the pageInfo property, but this is also a protected property of the NewContentElementController object
