### PR TITLE
[TASK] make it compatible with TYPO3 9.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -76,6 +76,9 @@ jobs:
       env: TYPO3=dev-master
     - stage: test
       php: 7.2
+      env: TYPO3=~9.3.0
+    - stage: test
+      php: 7.2
       env: TYPO3=~9.2.0
     - stage: test
       php: 7.2

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require": {
-        "typo3/cms-backend": "^8.7 || >=9.1 <9.3"
+        "typo3/cms-backend": "^8.7 || >=9.1 <9.4"
     },
     "require-dev": {
         "nimut/testing-framework": "4.x-dev"

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -26,7 +26,7 @@ $EM_CONF[$_EXTKEY] = array (
   array (
     'depends' => 
     array (
-      'typo3' => '8.7.0-9.2.99',
+      'typo3' => '8.7.0-9.3.99',
     ),
     'conflicts' => 
     array (


### PR DESCRIPTION
At the moment it is not possible to install content_defender within TYPO3 9.3. But it works like it worked with 9.2.