### PR TITLE
[BUGFIX] Do not filter colPos when comparison field is empty

### DIFF
--- a/Classes/Form/FormDataProvider/TcaColPosItems.php
+++ b/Classes/Form/FormDataProvider/TcaColPosItems.php
@@ -67,7 +67,7 @@ class TcaColPosItems implements FormDataProviderInterface
 
             $allowedConfiguration = $columnConfiguration['allowed.'] ?? [];
             foreach ($allowedConfiguration as $field => $value) {
-                if (!isset($record[$field])) {
+                if (empty($record[$field])) {
                     continue;
                 }
 
@@ -79,7 +79,7 @@ class TcaColPosItems implements FormDataProviderInterface
 
             $disallowedConfiguration = $columnConfiguration['disallowed.'] ?? [];
             foreach ($disallowedConfiguration as $field => $value) {
-                if (!isset($record[$field])) {
+                if (empty($record[$field])) {
                     continue;
                 }
 


### PR DESCRIPTION
**Problem**
When editing an existing content element, the colPos field may have no values.
This happens when another field than `CType` is defined (e.g. `list_type`) and the matching field in record is empty.

**How to reproduce:**
1. Setup a TYPO3 v9 instance and install extension
2. Create a backend layout with the following config:
```
mod.web_layout.BackendLayouts.default {
  title = Default
  config {
    backend_layout {
      colCount = 1
      rowCount = 1
      rows {
        1 {
          columns {
            1 {
              name = Content
              colPos = 0
              colspan = 1
              allowed {
                CType = textmedia, list
                list_type = news_pi1
              }
            }
          }
        }
      }
    }
  }
}
```
3. Select newly crated backend_layout
4. Create and save a textmedia element in this column
5. Edit the textmedia element again - The field colPos is empty


