### PR TITLE
Process only available fields

### DIFF
--- a/Classes/Form/FormDataProvider/TcaCTypeItems.php
+++ b/Classes/Form/FormDataProvider/TcaCTypeItems.php
@@ -40,12 +40,8 @@ class TcaCTypeItems implements FormDataProviderInterface
             return $result;
         }
 
-        $allowedConfiguration = $columnConfiguration['allowed.'] ?? [];
+        $allowedConfiguration = array_intersect_key($columnConfiguration['allowed.'] ?? [], $result['processedTca']['columns']);
         foreach ($allowedConfiguration as $field => $value) {
-            if (empty($result['processedTca']['columns'][$field]['config']['items'])) {
-                continue;
-            }
-
             $allowedValues = GeneralUtility::trimExplode(',', $value);
             $result['processedTca']['columns'][$field]['config']['items'] = array_filter(
                 $result['processedTca']['columns'][$field]['config']['items'],
@@ -55,12 +51,8 @@ class TcaCTypeItems implements FormDataProviderInterface
             );
         }
 
-        $disallowedConfiguration = $columnConfiguration['disallowed.'] ?? [];
+        $disallowedConfiguration = array_intersect_key($columnConfiguration['disallowed.'] ?? [], $result['processedTca']['columns']);
         foreach ($disallowedConfiguration as $field => $value) {
-            if (empty($result['processedTca']['columns'][$field]['config']['items'])) {
-                continue;
-            }
-
             $disAllowedValues = GeneralUtility::trimExplode(',', $value);
             $result['processedTca']['columns'][$field]['config']['items'] = array_filter(
                 $result['processedTca']['columns'][$field]['config']['items'],

--- a/Classes/Form/FormDataProvider/TcaColPosItems.php
+++ b/Classes/Form/FormDataProvider/TcaColPosItems.php
@@ -65,7 +65,7 @@ class TcaColPosItems implements FormDataProviderInterface
 
             $record['colPos'] = $colPos;
 
-            $allowedConfiguration = $columnConfiguration['allowed.'] ?? [];
+            $allowedConfiguration = array_intersect_key($columnConfiguration['allowed.'] ?? [], $result['processedTca']['columns']);
             foreach ($allowedConfiguration as $field => $value) {
                 if (!isset($record[$field])) {
                     continue;
@@ -77,7 +77,7 @@ class TcaColPosItems implements FormDataProviderInterface
                 }
             }
 
-            $disallowedConfiguration = $columnConfiguration['disallowed.'] ?? [];
+            $disallowedConfiguration = array_intersect_key($columnConfiguration['disallowed.'] ?? [], $result['processedTca']['columns']);
             foreach ($disallowedConfiguration as $field => $value) {
                 if (!isset($record[$field])) {
                     continue;

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ columns {
 
 **Combine multiple content element fields**
 
-- In order to restrict content elements using multple field conditions, please note that it might be necessary to allow empty values as well. A basic example would be to allow multiple content element types (text and list) while restricting plugin types to `news` only. If the editor wants to add a new text element, the plugin type stays empty.
+- The example allows multiple content element types (text and list) while restricting plugin types to `news` only.
 
 *Example:*
 ```
@@ -59,7 +59,7 @@ columns {
         colspan = 6
         allowed {
             CType = textmedia, list
-            list_type = ,news_pi1
+            list_type = news_pi1
         }
     }
 }

--- a/Tests/Functional/Fixtures/Database/tt_content.xml
+++ b/Tests/Functional/Fixtures/Database/tt_content.xml
@@ -34,6 +34,7 @@
         <pid>4</pid>
         <header>Text &amp; Media</header>
         <CType>textmedia</CType>
+        <sorting>128</sorting>
     </tt_content>
     <tt_content>
         <uid>6</uid>
@@ -41,5 +42,13 @@
         <header>Text &amp; Media (deleted)</header>
         <CType>textmedia</CType>
         <deleted>1</deleted>
+        <sorting>256</sorting>
+    </tt_content>
+    <tt_content>
+        <uid>7</uid>
+        <pid>4</pid>
+        <header>Header without list_type</header>
+        <CType>header</CType>
+        <sorting>64</sorting>
     </tt_content>
 </dataset>

--- a/Tests/Functional/Fixtures/TSconfig/BackendLayouts/Subpage.ts
+++ b/Tests/Functional/Fixtures/TSconfig/BackendLayouts/Subpage.ts
@@ -25,11 +25,12 @@ mod.web_layout.BackendLayouts.subpage {
             2 {
                 columns {
                     1 {
-                        name = Footer1 (no bullets)
+                        name = Footer1 (header, list[indexed_search_pi2])
                         colPos = 10
                         colspan = 2
-                        disallowed {
-                            CType = bullets
+                        allowed {
+                            CType = header, list
+                            list_type = indexed_search_pi2
                         }
                     }
 

--- a/Tests/Functional/Form/FormDataProvider/TcaColPosItemsTest.php
+++ b/Tests/Functional/Form/FormDataProvider/TcaColPosItemsTest.php
@@ -22,7 +22,7 @@ use TYPO3\CMS\Backend\Form\FormDataCompiler;
 use TYPO3\CMS\Backend\Form\FormDataGroup\TcaDatabaseRecord;
 use TYPO3\CMS\Core\DataHandling\DataHandler;
 
-class TcaColPostemsTest extends AbstractFunctionalTestCase
+class TcaColPosItemsTest extends AbstractFunctionalTestCase
 {
     /**
      * @test
@@ -47,6 +47,12 @@ class TcaColPostemsTest extends AbstractFunctionalTestCase
                 '12',
                 null,
                 null,
+            ],
+        ];
+
+        $_GET['defVals'] = [
+            'tt_content' => [
+                'CType' => 'header',
             ],
         ];
 

--- a/Tests/Functional/Form/FormDataProvider/TcaColPosItemsTest.php
+++ b/Tests/Functional/Form/FormDataProvider/TcaColPosItemsTest.php
@@ -37,7 +37,7 @@ class TcaColPosItemsTest extends AbstractFunctionalTestCase
                 null,
             ],
             2 => [
-                'Footer1 (no bullets)',
+                'Footer1 (header, list[indexed_search_pi2])',
                 '10',
                 null,
                 null,

--- a/Tests/Functional/Hooks/CmdmapDataHandlerHookTest.php
+++ b/Tests/Functional/Hooks/CmdmapDataHandlerHookTest.php
@@ -71,6 +71,29 @@ class CmdmapDataHandlerHookTest extends AbstractFunctionalTestCase
     /**
      * @test
      */
+    public function moveCommandMovesRecordWithEmptyListType()
+    {
+        $dataMap['tt_content'][7] = [
+            'colPos' => 10,
+        ];
+
+        $commandMap['tt_content'][7] = [
+            'move' => 4,
+        ];
+
+        $dataHandler = new DataHandler();
+        $dataHandler->start($dataMap, $commandMap);
+        $dataHandler->process_datamap();
+        $dataHandler->process_cmdmap();
+
+        $count = $this->getDatabaseConnection()->selectCount('*', 'tt_content', 'uid=7 AND colPos=10 AND sorting=64');
+
+        $this->assertSame(1, $count);
+    }
+
+    /**
+     * @test
+     */
     public function moveCommandPreventsDisallowedRecordInNewColPos()
     {
         $dataMap['tt_content'][3] = [
@@ -181,6 +204,31 @@ class CmdmapDataHandlerHookTest extends AbstractFunctionalTestCase
 
         $recordUid = $dataHandler->copyMappingArray['tt_content'][2];
         $count = $this->getDatabaseConnection()->selectCount('*', 'tt_content', 'uid=' . $recordUid . ' AND colPos=0');
+
+        $this->assertSame(1, $count);
+    }
+
+    /**
+     * @test
+     */
+    public function copyCommandMovesRecordInAllowedColPosWithEmptyListType()
+    {
+        $commandMap['tt_content'][2] = [
+            'move' => [
+                'action' => 'paste',
+                'target' => 3,
+                'update' => [
+                    'colPos' => '10',
+                ],
+            ],
+        ];
+
+        $dataHandler = new DataHandler();
+        $dataHandler->start([], $commandMap);
+        $dataHandler->process_datamap();
+        $dataHandler->process_cmdmap();
+
+        $count = $this->getDatabaseConnection()->selectCount('*', 'tt_content', 'uid=2 AND colPos=10');
 
         $this->assertSame(1, $count);
     }


### PR DESCRIPTION
This removes empty value handling for e.g. list_type field if a CType other than list is allowed as well.