### PR TITLE
Process all select items

### DIFF
--- a/Classes/Form/FormDataProvider/TcaCTypeItems.php
+++ b/Classes/Form/FormDataProvider/TcaCTypeItems.php
@@ -34,7 +34,7 @@ class TcaCTypeItems implements FormDataProviderInterface
         $pageId = !empty($result['effectivePid']) ? (int)$result['effectivePid'] : (int)$result['databaseRow']['pid'];
         $backendLayoutConfiguration = BackendLayoutConfiguration::createFromPageId($pageId);
 
-        $colPos = (int)$result['databaseRow']['colPos'];
+        $colPos = (int)($result['databaseRow']['colPos'][0] ?? ($result['databaseRow']['colPos'] ?? 0));
         $columnConfiguration = $backendLayoutConfiguration->getConfigurationByColPos($colPos);
         if (empty($columnConfiguration) || (empty($columnConfiguration['allowed.']) && empty($columnConfiguration['disallowed.']))) {
             return $result;
@@ -53,11 +53,11 @@ class TcaCTypeItems implements FormDataProviderInterface
 
         $disallowedConfiguration = array_intersect_key($columnConfiguration['disallowed.'] ?? [], $result['processedTca']['columns']);
         foreach ($disallowedConfiguration as $field => $value) {
-            $disAllowedValues = GeneralUtility::trimExplode(',', $value);
+            $disallowedValues = GeneralUtility::trimExplode(',', $value);
             $result['processedTca']['columns'][$field]['config']['items'] = array_filter(
                 $result['processedTca']['columns'][$field]['config']['items'],
-                function ($item) use ($disAllowedValues) {
-                    return !in_array($item[1], $disAllowedValues);
+                function ($item) use ($disallowedValues) {
+                    return !in_array($item[1], $disallowedValues);
                 }
             );
         }

--- a/Tests/Functional/Fixtures/Classes/Hooks/SimpleSelectboxSingleHook.php
+++ b/Tests/Functional/Fixtures/Classes/Hooks/SimpleSelectboxSingleHook.php
@@ -1,0 +1,43 @@
+<?php
+declare(strict_types=1);
+namespace IchHabRecht\ContentDefender\Tests\Functional\Fixtures\Classes\Hooks;
+
+class SimpleSelectboxSingleHook
+{
+    public function addSimpleSelectboxItems(array &$parameters)
+    {
+        $parameters['items'] = [
+            0 => [
+                1 => '0',
+            ],
+            1 => [
+                0 => 'tx_simpleselectboxsingle.I.1',
+                1 => '1',
+            ],
+            2 => [
+                0 => 'tx_simpleselectboxsingle.I.2',
+                1 => '2',
+            ],
+            3 => [
+                0 => 'tx_simpleselectboxsingle.I.3',
+                1 => '3',
+            ],
+            4 => [
+                0 => 'tx_simpleselectboxsingle.I.4',
+                1 => '4',
+            ],
+            5 => [
+                0 => 'tx_simpleselectboxsingle.I.5',
+                1 => '5',
+            ],
+            6 => [
+                0 => 'tx_simpleselectboxsingle.I.6',
+                1 => '6',
+            ],
+            7 => [
+                0 => 'tx_simpleselectboxsingle.I.7',
+                1 => '7',
+            ],
+        ];
+    }
+}

--- a/Tests/Functional/Fixtures/Configuration/TCA/Overrides/tt_content.php
+++ b/Tests/Functional/Fixtures/Configuration/TCA/Overrides/tt_content.php
@@ -1,0 +1,16 @@
+<?php
+
+$tempColumns = [
+    'tx_simpleselectboxsingle' => [
+        'label' => 'Simple select box',
+        'exclude' => '1',
+        'config' => [
+            'type' => 'select',
+            'renderType' => 'selectSingle',
+            'itemsProcFunc' => \IchHabRecht\ContentDefender\Tests\Functional\Fixtures\Classes\Hooks\SimpleSelectboxSingleHook::class . '->addSimpleSelectboxItems',
+        ],
+    ],
+];
+
+\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addTCAcolumns('tt_content', $tempColumns);
+\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addToAllTCAtypes('tt_content', 'tx_simpleselectboxsingle');

--- a/Tests/Functional/Fixtures/TSconfig/BackendLayouts/Default.ts
+++ b/Tests/Functional/Fixtures/TSconfig/BackendLayouts/Default.ts
@@ -54,8 +54,11 @@ mod.web_layout.BackendLayouts.default {
                     }
 
                     3 {
-                        name = Footer3 (all)
+                        name = Footer3 (all, tx_simpleselectboxsingle=5)
                         colPos = 12
+                        allowed {
+                            tx_simpleselectboxsingle = 5
+                        }
                     }
                 }
             }

--- a/Tests/Functional/Form/FormDataProvider/TcaCTypeItemsTest.php
+++ b/Tests/Functional/Form/FormDataProvider/TcaCTypeItemsTest.php
@@ -24,6 +24,13 @@ use TYPO3\CMS\Backend\Form\FormDataGroup\TcaDatabaseRecord;
 class TcaCTypeItemsTest extends AbstractFunctionalTestCase
 {
     /**
+     * @var array
+     */
+    protected $pathsToLinkInTestInstance = [
+        'typo3conf/ext/content_defender/Tests/Functional/Fixtures/Configuration' => 'typo3conf/ext/content_defender/Configuration',
+    ];
+
+    /**
      * @test
      */
     public function disallowedCTypesAreRemovedFromCTypeList()
@@ -52,5 +59,36 @@ class TcaCTypeItemsTest extends AbstractFunctionalTestCase
         $result = $formDataCompiler->compile($formDataCompilerInput);
 
         $this->assertSame($expected, array_values($result['processedTca']['columns']['CType']['config']['items']));
+    }
+
+    /**
+     * @test
+     */
+    public function disallowedItemsAreRemovedFromListWithItemsProcFunc()
+    {
+        $expected = [
+            0 => [
+                0 => 'tx_simpleselectboxsingle.I.5',
+                1 => '5',
+                2 => null,
+                3 => null,
+            ],
+        ];
+
+        $_GET['defVals']['tt_content'] = [
+            'colPos' => 12,
+            'CType' => 'header',
+        ];
+        $formDataCompilerInput = [
+            'command' => 'new',
+            'tableName' => 'tt_content',
+            'vanillaUid' => 2,
+        ];
+
+        $formDataGroup = new TcaDatabaseRecord();
+        $formDataCompiler = new FormDataCompiler($formDataGroup);
+        $result = $formDataCompiler->compile($formDataCompilerInput);
+
+        $this->assertSame($expected, array_values($result['processedTca']['columns']['tx_simpleselectboxsingle']['config']['items']));
     }
 }

--- a/Tests/Functional/Form/FormDataProvider/TcaCTypeItemsTest.php
+++ b/Tests/Functional/Form/FormDataProvider/TcaCTypeItemsTest.php
@@ -51,6 +51,6 @@ class TcaCTypeItemsTest extends AbstractFunctionalTestCase
         $formDataCompiler = new FormDataCompiler($formDataGroup);
         $result = $formDataCompiler->compile($formDataCompilerInput);
 
-        $this->assertSame($expected, $result['processedTca']['columns']['CType']['config']['items']);
+        $this->assertSame($expected, array_values($result['processedTca']['columns']['CType']['config']['items']));
     }
 }

--- a/Tests/Functional/Form/FormDataProvider/TcaColPosItemsTest.php
+++ b/Tests/Functional/Form/FormDataProvider/TcaColPosItemsTest.php
@@ -36,13 +36,13 @@ class TcaColPosItemsTest extends AbstractFunctionalTestCase
                 null,
                 null,
             ],
-            2 => [
+            1 => [
                 'Footer1 (header, list[indexed_search_pi2])',
                 '10',
                 null,
                 null,
             ],
-            4 => [
+            2 => [
                 'Footer3 (all)',
                 '12',
                 null,
@@ -66,7 +66,7 @@ class TcaColPosItemsTest extends AbstractFunctionalTestCase
         $formDataCompiler = new FormDataCompiler($formDataGroup);
         $result = $formDataCompiler->compile($formDataCompilerInput);
 
-        $this->assertSame($expected, $result['processedTca']['columns']['colPos']['config']['items']);
+        $this->assertSame($expected, array_values($result['processedTca']['columns']['colPos']['config']['items']));
     }
 
     /**
@@ -93,7 +93,7 @@ class TcaColPosItemsTest extends AbstractFunctionalTestCase
         $formDataCompiler = new FormDataCompiler($formDataGroup);
         $result = $formDataCompiler->compile($formDataCompilerInput);
 
-        $this->assertArraySubset($expected, $result['processedTca']['columns']['colPos']['config']['items']);
+        $this->assertArraySubset($expected, array_values($result['processedTca']['columns']['colPos']['config']['items']));
     }
 
     /**
@@ -108,13 +108,13 @@ class TcaColPosItemsTest extends AbstractFunctionalTestCase
                 null,
                 null,
             ],
-            3 => [
+            1 => [
                 'Footer2 (bullets)',
                 '11',
                 null,
                 null,
             ],
-            4 => [
+            2 => [
                 'Footer3 (all)',
                 '12',
                 null,
@@ -138,7 +138,7 @@ class TcaColPosItemsTest extends AbstractFunctionalTestCase
         $formDataCompiler = new FormDataCompiler($formDataGroup);
         $result = $formDataCompiler->compile($formDataCompilerInput);
 
-        $this->assertSame($expected, $result['processedTca']['columns']['colPos']['config']['items']);
+        $this->assertSame($expected, array_values($result['processedTca']['columns']['colPos']['config']['items']));
     }
 
     /**

--- a/ext_tables.php
+++ b/ext_tables.php
@@ -3,16 +3,13 @@ defined('TYPO3_MODE') || die('Access denied.');
 
 $GLOBALS['TYPO3_CONF_VARS']['SYS']['formEngine']['formDataGroup']['tcaDatabaseRecord'][\IchHabRecht\ContentDefender\Form\FormDataProvider\TcaCTypeItems::class] = [
     'depends' => [
-        \TYPO3\CMS\Backend\Form\FormDataProvider\DatabaseRowDefaultValues::class,
-    ],
-    'before' => [
         \TYPO3\CMS\Backend\Form\FormDataProvider\TcaSelectItems::class,
     ],
 ];
 
 $GLOBALS['TYPO3_CONF_VARS']['SYS']['formEngine']['formDataGroup']['tcaDatabaseRecord'][\IchHabRecht\ContentDefender\Form\FormDataProvider\TcaColPosItems::class] = [
     'depends' => [
-        \TYPO3\CMS\Backend\Form\FormDataProvider\TcaSelectItems::class,
+        \IchHabRecht\ContentDefender\Form\FormDataProvider\TcaCTypeItems::class,
     ],
 ];
 


### PR DESCRIPTION
This patch changes the DataProvider ordering to ensure all processed select items are available before allowed and disallowed values are processed.

Resolves: #58 