### PR TITLE
[BUGFIX] explicitly check if the colPos value is inside an array

### DIFF
--- a/Classes/Form/FormDataProvider/TcaCTypeItems.php
+++ b/Classes/Form/FormDataProvider/TcaCTypeItems.php
@@ -36,7 +36,11 @@ class TcaCTypeItems implements FormDataProviderInterface
         $pageId = !empty($result['effectivePid']) ? (int)$result['effectivePid'] : (int)$result['databaseRow']['pid'];
         $backendLayoutConfiguration = BackendLayoutConfiguration::createFromPageId($pageId);
 
-        $colPos = (int)($result['databaseRow']['colPos'][0] ?? ($result['databaseRow']['colPos'] ?? 0));
+        if (is_array($result['databaseRow']['colPos'])) {
+            $colPos = (int)$result['databaseRow']['colPos'][0];
+        } else {
+            $colPos = (int)$result['databaseRow']['colPos'];
+        }
         $columnConfiguration = $backendLayoutConfiguration->getConfigurationByColPos($colPos, $result['databaseRow']['uid']);
         if (empty($columnConfiguration) || (empty($columnConfiguration['allowed.']) && empty($columnConfiguration['disallowed.']))) {
             return $result;


### PR DESCRIPTION
I encountered this issue with typo3/cms-core:10.4 and gridelements:^10.

Scenario:
I have a backendlayout with restrictions on colPos "0" in my backendlayout. (allowed { CType = text,html } } )
In addition i have a simple gridelement with another restriction (allowed { CType = image } } )
Gridelements passes "-1" as colPos value but this value is parsed as "0" -> this results in wrong restrictions. 
The dropdown has text, html (wrong) and not image (expected)