### PR TITLE
a simple quickfix for the workspace bug

### DIFF
--- a/Classes/Hooks/AbstractDataHandlerHook.php
+++ b/Classes/Hooks/AbstractDataHandlerHook.php
@@ -121,6 +121,10 @@ abstract class AbstractDataHandlerHook
             return true;
         }
 
+        if ($record['t3ver_state'] !== 0) {
+            return true;
+        }
+
         return (int)$columnConfiguration['maxitems'] >= $this->contentRepository->addRecordToColPos($record);
     }
 }


### PR DESCRIPTION
when saving a record in a workspace in a colpos with maxitems set, content_defender always returns false in the method isRecordAllowedByItemsCount(). in that case, i added a simple check for the t3ver_state column and return true, if it is not "published"