### PR TITLE
[TASK] #105 Adjust colPos query for maxitems if b13/container is active

### DIFF
--- a/Classes/Repository/ContentRepository.php
+++ b/Classes/Repository/ContentRepository.php
@@ -29,15 +29,13 @@ class ContentRepository
 {
     protected ColPosCountState $colPosCount;
 
-    protected PackageManager $packageManager;
-
     protected bool $isContainerExtensionInstalled;
 
-    public function __construct(ColPosCountState $colPosCount = null, PackageManager $packageManager)
+    public function __construct(ColPosCountState $colPosCount = null)
     {
         $this->colPosCount = $colPosCount ?? GeneralUtility::makeInstance(ColPosCountState::class);
-        $this->packageManager = $packageManager;
-        $this->isContainerExtensionInstalled = $this->packageManager->isPackageActive('b13/container');
+        $this->isContainerExtensionInstalled = GeneralUtility::makeInstance(PackageManager::class)
+            ->isPackageActive('b13/container');
     }
 
     public function countColPosByRecord(array $record): int

--- a/Classes/Repository/ContentRepository.php
+++ b/Classes/Repository/ContentRepository.php
@@ -22,6 +22,7 @@ use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Database\Query\Restriction\BackendWorkspaceRestriction;
 use TYPO3\CMS\Core\Database\Query\Restriction\HiddenRestriction;
 use TYPO3\CMS\Core\Package\PackageManager;
+use TYPO3\CMS\Core\Service\DependencyOrderingService;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Core\Versioning\VersionState;
 
@@ -34,7 +35,10 @@ class ContentRepository
     public function __construct(ColPosCountState $colPosCount = null)
     {
         $this->colPosCount = $colPosCount ?? GeneralUtility::makeInstance(ColPosCountState::class);
-        $this->isContainerExtensionInstalled = GeneralUtility::makeInstance(PackageManager::class)
+        $this->isContainerExtensionInstalled = GeneralUtility::makeInstance(
+            PackageManager::class,
+            GeneralUtility::makeInstance(DependencyOrderingService::class)
+        )
             ->isPackageActive('b13/container');
     }
 


### PR DESCRIPTION
Hi Nicole,

I'm not sure if you're fond of such big code changes.
Generally, I understand if you don't want to add code specific to `b13/container` at all. If I remember correctly, this extension also tries to fix issues with `colPos` from its own side.

There is probably a tradeoff comparing `container` to `gridelements` which uses colPos=-1 here.

Trying to fix issue #105

Based on the comment provided by Tomas Havner in

https://github.com/IchHabRecht/content_defender/issues/105#issuecomment-1240721063

Of course feel free to edit or deny the PR!

The problem seems to be inherent to the combination of `content-defender` with `b13/container`.

The "isPackageActive"-logic surely could be refactored out of the Repository.
//EDIT: 
And I would personally prefer not to have to make this indirect check at all.
If it isn't too expensive, one could also check for existence of the database column `tt_content.tx_container_parent` using Doctrine.
Which would also bloat the code.

NO UNIT TEST YET.

Best,
Moritz