### PR TITLE
gray badge

### DIFF
--- a/Resources/Private/Partials/Backend/PageLayout/Grid/ColumnHeader.html
+++ b/Resources/Private/Partials/Backend/PageLayout/Grid/ColumnHeader.html
@@ -6,19 +6,21 @@
 
 <cd:extendPartial>
     <f:alias map="{maxitems: '{cd:maxitems(column: column)}'}">
-        <div class="t3-cd-badge-container" data-maxitems="{maxitems}">
-            <f:switch expression="{maxitems}">
-                <f:case value="-1"></f:case>
-                <f:case value="1">
-                    <span class="badge text-bg-warning t3-cd-badge">{maxitems}</span>
-                </f:case>
-                <f:case value="0">
-                    <span class="badge text-bg-danger t3-cd-badge">{maxitems}</span>
-                </f:case>
-                <f:defaultCase>
-                    <span class="badge text-bg-success t3-cd-badge">{maxitems}</span>
-                </f:defaultCase>
-            </f:switch>
+
+        <f:if condition="{maxitems} > 9">
+            <f:variable name="length" value="2"/>
+        </f:if>
+
+        <f:if condition="{maxitems} > 99">
+            <f:variable name="length" value="3"/>
+        </f:if>
+
+        <div class="t3-cd-badge-container{f:if(condition: '{length} > 1', then: ' t3-cd-badge-container-length-{length}')}" data-maxitems="{maxitems}">
+            <f:if condition="{maxitems} >= 0">
+                <span class="badge t3-cd-badge">
+                    {f:if(condition: '{maxitems} > 99', then: '&#43;99', else: '{maxitems}')}
+                </span>
+            </f:if>
             <f:render partial="PageLayout/Grid/ColumnHeader" arguments="{_all}" />
         </div>
     </f:alias>

--- a/Resources/Private/Partials/Backend/PageLayout/Record.html
+++ b/Resources/Private/Partials/Backend/PageLayout/Record.html
@@ -3,7 +3,16 @@
     data-namespace-typo3-fluid="true">
 <cd:extendPartial>
     <f:alias map="{maxitems: '{cd:maxitems(column: column)}'}">
-        <div class="t3-cd-badge-container" data-maxitems="{maxitems}">
+
+        <f:if condition="{maxitems} > 9">
+            <f:variable name="length" value="2"/>
+        </f:if>
+
+        <f:if condition="{maxitems} > 99">
+            <f:variable name="length" value="3"/>
+        </f:if>
+
+        <div class="t3-cd-badge-container{f:if(condition: '{length} > 1', then: ' t3-cd-badge-container-length-{length}')}" data-maxitems="{maxitems}">
             <f:render partial="PageLayout/Record" arguments="{_all}" />
         </div>
     </f:alias>

--- a/Resources/Public/Css/backend.css
+++ b/Resources/Public/Css/backend.css
@@ -1,34 +1,37 @@
 @charset "UTF-8";
 
+.t3js-page-column .t3-cd-badge-container[data-maxitems="0"] .t3-page-ce .t3js-page-new-ce,
+.t3js-page-column .t3-cd-badge-container[data-maxitems="0"] .t3-page-ce .t3-page-ce-dropzone {
+    display: none;
+}
+
+body[style="cursor: move;"] .t3js-page-column .t3-cd-badge-container[data-maxitems="0"] .t3-page-ce .t3js-page-new-ce,
+body[style="cursor: move;"].t3js-page-column .t3-cd-badge-container[data-maxitems="0"] .t3-page-ce .t3-page-ce-dropzone {
+    display: block;
+    visibility: hidden;
+}
+
+.t3-cd-badge-container:not([data-maxitems="-1"]) .t3-page-column-header {
+    padding-left: 25px;
+}
+
+.t3-cd-badge-container:not([data-maxitems="-1"]).t3-cd-badge-container-length-2 .t3-page-column-header {
+    padding-left: 30px;
+}
+
+.t3-cd-badge-container:not([data-maxitems="-1"]).t3-cd-badge-container-length-3 .t3-page-column-header {
+    padding-left: 40px;
+}
+
 .t3-cd-badge-container {
     position: relative;
 }
 
-.t3-cd-badge-container[data-maxitems="0"] .t3-page-ce .t3js-page-new-ce,
-.t3-cd-badge-container[data-maxitems="0"] .t3-page-ce .t3-page-ce-dropzone {
-    display: none;
-}
-
 .t3-cd-badge {
     position: absolute;
+    z-index: 1;
     left: 0;
-    top: 0;
-    transform: translate(-50%, 0);
-    background-color: #ff0000;
-    z-index: 100;
-}
-
-.t3-cd-badge.text-bg-success {
-    background-color: #107c10;
-    color: #ffffff;
-}
-
-.t3-cd-badge.text-bg-warning {
-    background-color: #e8a33d;
-    color: #ffffff;
-}
-
-.t3-cd-badge.text-bg-danger {
-    background-color: #ff0000;
-    color: #ffffff;
+    top: 21px;
+    background-color: #eaeaea;
+    color: #000000;
 }


### PR DESCRIPTION
Hi @IchHabRecht 

I made the Style of the badge and fixed some issues with the drag and drop area. 

I tried to place the badge without an absolute position, but i had to change too much on the wrapping element styles. 
So i went back to the absolute positioning. Because of that the badge is placed in front of the column title. 

<img width="338" alt="Bildschirm­foto 2023-02-09 um 09 43 10" src="https://user-images.githubusercontent.com/25507655/217786829-7b649fe0-c1eb-41c7-8cef-9eee0d13785b.png">

Depending of the length of the badge, i gave a «padding-left» to the column title. Because of that i set a limit to the maxitem variable. If there is a value over 99, i write a string «+99» to the badge. 

<img width="432" alt="Bildschirm­foto 2023-02-09 um 09 36 01" src="https://user-images.githubusercontent.com/25507655/217786821-74891db3-29aa-4e75-94d9-ae56a18689af.png">

<img width="333" alt="Bildschirm­foto 2023-02-09 um 09 42 51" src="https://user-images.githubusercontent.com/25507655/217786826-13edc9cc-39b5-4b82-b2c0-acfa53b299e2.png">

Greets Ben
