### PR TITLE
[BUGFIX] Avoid unsafe array access to colPos

### DIFF
--- a/Classes/Hooks/DatamapDataHandlerHook.php
+++ b/Classes/Hooks/DatamapDataHandlerHook.php
@@ -50,7 +50,7 @@ class DatamapDataHandlerHook extends AbstractDataHandlerHook
                 $pageId = (int)$previousRecord['pid'];
                 $incomingFieldArray['pid'] = $pageId;
             }
-            $colPos = (int)$incomingFieldArray['colPos'];
+            $colPos = (int)($incomingFieldArray['colPos'] ?? 0);
 
             $backendLayoutConfiguration = BackendLayoutConfiguration::createFromPageId($pageId);
             $columnConfiguration = $backendLayoutConfiguration->getConfigurationByColPos($colPos, $id);


### PR DESCRIPTION
When content elements are created as inline records (for example in news) they usually don't come with a colPos. This results in a fatal error with PHP 8.