### PR TITLE
[BUGFIX] Preserve CType group labels when using `allowed`

### DIFF
--- a/Classes/Form/FormDataProvider/TcaCTypeItems.php
+++ b/Classes/Form/FormDataProvider/TcaCTypeItems.php
@@ -54,7 +54,7 @@ class TcaCTypeItems implements FormDataProviderInterface
             $result['processedTca']['columns'][$field]['config']['items'] = array_filter(
                 $result['processedTca']['columns'][$field]['config']['items'],
                 function ($item) use ($allowedValues) {
-                    return in_array($item['value'] ?? $item[1], $allowedValues);
+                    return in_array($item['value'] ?? $item[1], $allowedValues) || $item['value'] === '--div--';
                 }
             );
         }

--- a/Classes/Form/FormDataProvider/TcaCTypeItems.php
+++ b/Classes/Form/FormDataProvider/TcaCTypeItems.php
@@ -54,7 +54,7 @@ class TcaCTypeItems implements FormDataProviderInterface
             $result['processedTca']['columns'][$field]['config']['items'] = array_filter(
                 $result['processedTca']['columns'][$field]['config']['items'],
                 function ($item) use ($allowedValues) {
-                    return in_array($item['value'] ?? $item[1], $allowedValues) || $item['value'] === '--div--';
+                    return $item['value'] ?? $item[1] === '--div--' || in_array($item['value'] ?? $item[1], $allowedValues);
                 }
             );
         }


### PR DESCRIPTION
This change ensures, that item group labels are left out when filtering the `allowed` array of CType items.

Closes #149