### PR TITLE
[BUGFIX] Fix deprecation warnings

### DIFF
--- a/Classes/Form/FormDataProvider/TcaColPosItems.php
+++ b/Classes/Form/FormDataProvider/TcaColPosItems.php
@@ -33,7 +33,7 @@ class TcaColPosItems implements FormDataProviderInterface
     /**
      * @param ContentRepository $contentRepository
      */
-    public function __construct(ContentRepository $contentRepository = null)
+    public function __construct(?ContentRepository $contentRepository = null)
     {
         $this->contentRepository = $contentRepository ?? GeneralUtility::makeInstance(ContentRepository::class);
     }

--- a/Classes/Hooks/AbstractDataHandlerHook.php
+++ b/Classes/Hooks/AbstractDataHandlerHook.php
@@ -43,7 +43,7 @@ abstract class AbstractDataHandlerHook
     /**
      * @param ContentRepository $contentRepository
      */
-    public function __construct(ContentRepository $contentRepository = null)
+    public function __construct(?ContentRepository $contentRepository = null)
     {
         $this->contentRepository = $contentRepository ?? GeneralUtility::makeInstance(ContentRepository::class);
         $this->versionBranch = (new Typo3Version())->getBranch();

--- a/Classes/Repository/ColPosCountState.php
+++ b/Classes/Repository/ColPosCountState.php
@@ -29,7 +29,7 @@ class ColPosCountState implements \ArrayAccess, \Countable, \Iterator
 
     protected int $position = 0;
 
-    public function __construct(FrontendInterface $cache = null, $cacheIdentifier = 'tx_contentdefender_colPosCount', $data = null)
+    public function __construct(?FrontendInterface $cache = null, $cacheIdentifier = 'tx_contentdefender_colPosCount', $data = null)
     {
         $this->cache = $cache ?? GeneralUtility::makeInstance(CacheManager::class)->getCache('runtime');
         $this->cacheIdentifier = $cacheIdentifier;

--- a/Classes/Repository/ContentRepository.php
+++ b/Classes/Repository/ContentRepository.php
@@ -30,7 +30,7 @@ class ContentRepository
 {
     protected ColPosCountState $colPosCount;
 
-    public function __construct(ColPosCountState $colPosCount = null)
+    public function __construct(?ColPosCountState $colPosCount = null)
     {
         $this->colPosCount = $colPosCount ?? GeneralUtility::makeInstance(ColPosCountState::class);
     }


### PR DESCRIPTION
As of PHP 8.4 implicitly declaring function parameters nullable is deprecated.

Explicitly nullable types have been available since PHP 7.1

See: https://php.watch/versions/8.4/implicitly-marking-parameter-type-nullable-deprecated