### PR TITLE
Prevent copy a record to loaded column

### DIFF
--- a/Classes/Hooks/CmdmapDataHandlerHook.php
+++ b/Classes/Hooks/CmdmapDataHandlerHook.php
@@ -20,6 +20,7 @@ namespace IchHabRecht\ContentDefender\Hooks;
 use IchHabRecht\ContentDefender\BackendLayout\BackendLayoutConfiguration;
 use TYPO3\CMS\Backend\Utility\BackendUtility;
 use TYPO3\CMS\Core\DataHandling\DataHandler;
+use TYPO3\CMS\Core\Utility\StringUtility;
 
 class CmdmapDataHandlerHook extends AbstractDataHandlerHook
 {
@@ -42,7 +43,10 @@ class CmdmapDataHandlerHook extends AbstractDataHandlerHook
 
                 $currentRecord = BackendUtility::getRecord('tt_content', $id);
 
-                if ($command === 'move') {
+                if ($command === 'copy') {
+                    // Enforce a new uid when copying a record to ensure correct maxItems validation
+                    $currentRecord['uid'] .= StringUtility::getUniqueId('-NEW');
+                } else {
                     // New colPos is passed as datamap array and already processed in processDatamap_beforeStart
                     $data = isset($dataHandler->datamap['tt_content'][$id])
                         ? $dataHandler->datamap : ($_POST['data'] ?? $_GET['data'] ?? null);

--- a/Tests/Functional/Hooks/CmdmapDataHandlerHookTest.php
+++ b/Tests/Functional/Hooks/CmdmapDataHandlerHookTest.php
@@ -430,6 +430,30 @@ class CmdmapDataHandlerHookTest extends AbstractFunctionalTestCase
     /**
      * @test
      */
+    public function copyCommandPreventsSameRecordInLoadedColumn()
+    {
+        $commandMap['tt_content'][4] = [
+            'copy' => [
+                'action' => 'paste',
+                'target' => '-4',
+                'update' => [
+                    'colPos' => '0',
+                    'sys_language_uid' => '0',
+                ],
+            ],
+        ];
+
+        $dataHandler = GeneralUtility::makeInstance(DataHandler::class);
+        $dataHandler->start([], $commandMap);
+        $dataHandler->process_datamap();
+        $dataHandler->process_cmdmap();
+
+        $this->assertArrayNotHasKey('tt_content', $dataHandler->copyMappingArray);
+    }
+
+    /**
+     * @test
+     */
     public function copyCommandCopiesOnlyOneRecordToMaxitemsColPos()
     {
         $_GET['CB']['paste'] = '|3';

--- a/Tests/Functional/Hooks/CmdmapDataHandlerHookTest.php
+++ b/Tests/Functional/Hooks/CmdmapDataHandlerHookTest.php
@@ -498,7 +498,7 @@ class CmdmapDataHandlerHookTest extends AbstractFunctionalTestCase
         $commandMap['tt_content'][4] = [
             'copy' => [
                 'action' => 'paste',
-                'target' => 3,
+                'target' => 4,
                 'update' => [
                     'colPos' => '3',
                 ],


### PR DESCRIPTION
To calculate the count of a column the already available record uids are used as key values.
If a record is pasted after itself the count isn't increased correctly as the uid of both records (the existing and the new one) are the same and thus the array count doesn't change.

The patch ensures that the new record is evaluated with its own (unique) uid.

Resolves: #166